### PR TITLE
⌗120857 | Persistent Object Caching Edge-Case

### DIFF
--- a/tribe-ext-remove-eb-migration-transient.php
+++ b/tribe-ext-remove-eb-migration-transient.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Eventbrite Tickets Extension: Clean Up Migration Data
  * Description: Older versions of Eventbrite Tickets would sometimes add a transient with no expiration date. This extension removes that transient if it exists.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Modern Tribe, Inc.
  * Author URI: http://m.tri.be/1971
  * License: GPLv2 or later
@@ -105,6 +105,12 @@ class Tribe__Extension__Remove_Eventbrite_Migration_Transient {
      * @return boolean
      */
     public function old_transient_exists() {
+        
+        // If we're using persistent object caching, we are going to delete the transient in all cases.
+        if ( wp_using_ext_object_cache() ) {
+            return true;
+        }
+        
         $transient         = get_transient( self::$transient_key );
         $transient_timeout = (bool) get_option( '_transient_timeout_' . self::$transient_key );
 

--- a/tribe-ext-remove-eb-migration-transient.php
+++ b/tribe-ext-remove-eb-migration-transient.php
@@ -125,6 +125,11 @@ class Tribe__Extension__Remove_Eventbrite_Migration_Transient {
      * @return bool true if successful, false otherwise
      */
     public function maybe_delete_old_transient() {
+        
+        // If a deletion has already run, don't attempt another one.
+        if ( 'true' === get_option( self::$deleted_key ) ) {
+            return false;
+        }
 
         if ( ! $this->old_transient_exists() ) {
             add_option( self::$deleted_key, 'false' );


### PR DESCRIPTION
Skip to the front of the line if persistent object caching is present, since in that case there won't be a corresponding `transient_timeout` option. See here for reference: https://core.trac.wordpress.org/browser/tags/5.0.3/src/wp-includes/option.php#L755

**Ticket:** [**⌗120857**](http://central.tri.be/issues/120857)